### PR TITLE
chore: expose public API, ship py.typed, enrich metadata

### DIFF
--- a/caneth/__init__.py
+++ b/caneth/__init__.py
@@ -1,12 +1,14 @@
-"""caneth — Asyncio CAN client for Waveshare 2-CH-CAN-TO-ETH.
+"""Top-level package for caneth.
 
-Public API:
-    - WaveShareCANClient: Async client with auto-reconnect and callback registry
-    - CANFrame: Dataclass representing a CAN frame
-    - parse_hex_bytes: Utility to parse human-friendly hex strings
+This module exposes the primary public API and configures library-friendly logging.
 """
 
 from .client import CANFrame, WaveShareCANClient
 from .utils import parse_hex_bytes
 
-__all__ = ["WaveShareCANClient", "CANFrame", "parse_hex_bytes"]
+__all__ = ["CANFrame", "WaveShareCANClient", "parse_hex_bytes"]
+
+# Library-friendly logging: don't emit logs unless the app configures handlers.
+import logging as _logging
+
+_logging.getLogger(__name__).addHandler(_logging.NullHandler())

--- a/caneth/py.typed
+++ b/caneth/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561 (typed package)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,20 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Framework :: AsyncIO",
+  "Topic :: System :: Networking",
+  "Typing :: Typed",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
+
+[project.urls]
+Homepage = "https://github.com/kstaniek/caneth"
+Documentation = "https://kstaniek.github.io/caneth/"
+Source = "https://github.com/kstaniek/caneth"
+Issues = "https://github.com/kstaniek/caneth/issues"
+Changelog = "https://github.com/kstaniek/caneth/releases"
 
 [project.scripts]
 caneth = "caneth.cli:main"
@@ -48,3 +59,7 @@ ignore_missing_imports = true
 strict_optional = true
 scripts_are_modules = true
 packages = ["caneth"]
+
+[tool.setuptools.package-data]
+caneth = ["py.typed"]
+


### PR DESCRIPTION
# Summary (PR description)
- Export CANFrame, WaveShareCANClient, and parse_hex_bytes at package top-level.
- Add logging.NullHandler() for library-friendly logging by default.
- Ship py.typed (PEP 561) so type checkers know your package is typed.
- Add helpful project.urls to pyproject.toml and include py.typed in package data.