### PR TITLE
ci: split lint/type/test, enable tokenless Codecov, add PyPI Trusted …

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install ruff
+        run: python -m pip install -U pip ruff
+
+      - name: Format check + lint
+        run: |
+          ruff format --check
+          ruff check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
-name: CI
+name: Tests
 
 on:
   push:
-    branches: [ "**" ]
+    branches: ["**"]
   pull_request:
 
 jobs:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write   # required for tokenless upload with codecov-action v4
+      id-token: write   # required for tokenless Codecov upload (OIDC)
     strategy:
       fail-fast: false
       matrix:
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -37,7 +37,8 @@ jobs:
       - name: Install
         run: |
           python -m pip install -U pip
-          pip install -e . pytest pytest-asyncio pytest-cov
+          pip install -e .
+          pip install pytest pytest-asyncio pytest-cov
 
       - name: Test
         run: |
@@ -49,11 +50,11 @@ jobs:
           name: coverage-xml-${{ matrix.python-version }}
           path: coverage.xml
 
-      # Tokenless upload for PUBLIC repos using OIDC (v4)
-      # Limit to one Python version to avoid noisy duplicate uploads.
+      # Tokenless upload to Codecov via OIDC (public repos)
+      # Upload once to reduce duplicate reports
       - name: Upload to Codecov
         if: ${{ !github.event.repository.private && matrix.python-version == '3.13' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
           name: coverage-${{ matrix.python-version }}

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -1,0 +1,24 @@
+name: Type Check
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  mypy:
+    name: mypy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install mypy
+        run: python -m pip install -U pip mypy
+
+      - name: Type check
+        run: mypy caneth


### PR DESCRIPTION
## Summary

- Add lint and type workflows for fast feedback on style and typing.
- Replace unified CI with a dedicated tests workflow (matrix 3.9–3.13) and tokenless Codecov (OIDC) upload (once per matrix).
- Add publish workflow using PyPI Trusted Publishing (OIDC) on tags v*.
- Remove old .github/workflows/ci.yaml to avoid duplicate runs.