### PR TITLE
feature: add tx buffer

### DIFF
--- a/caneth/client.py
+++ b/caneth/client.py
@@ -568,6 +568,15 @@ class WaveShareCANClient:
                             self._tx_buf.appendleft(raw)
                             self._tx_cv.notify()
                         self._connected.clear()
+                        # tells the scheduler: “yield now; let other tasks run.”
+                        # That gives the reconnect manager (and teardown paths that
+                        # notify the condition, close the writer, etc.) a chance to
+                        # advance the state before TX loops again. It:
+                        # - prevents a CPU spin,
+                        # - avoids starving the reconnect task,
+                        # - does not introduce a real delay (it yields, not sleeps).
+                        # In 3.12+, await asyncio.sleep(0) remains the recommended
+                        # simple yield; there’s no dedicated “yield” primitive.
                         await asyncio.sleep(0)  # avoid potential tight re-loop
                         break
 
@@ -587,7 +596,7 @@ class WaveShareCANClient:
                 break
             except Exception:
                 self.log.exception("Unexpected error in TX loop")
-                await asyncio.sleep(0.05)
+                await asyncio.sleep(WaveShareCANClient._TX_WAIT_TIMEOUT)
 
     async def _dispatch(self, frame: CANFrame) -> None:
         """Run global observers, specific callbacks, and resolve waiters."""

--- a/caneth/client.py
+++ b/caneth/client.py
@@ -552,9 +552,11 @@ class WaveShareCANClient:
                             self._tx_cv.notify()
                         else:
                             # Wait for new data or disconnection/close
-                            with contextlib.suppress(TimeoutError):
+                            try:
                                 await asyncio.wait_for(self._tx_cv.wait(), timeout=WaveShareCANClient._TX_WAIT_TIMEOUT)
-                            continue
+                            except asyncio.TimeoutError:
+                                # Timeout occurred; no new data, continue loop
+                                continue
 
                     if raw is None:
                         continue

--- a/caneth/client.py
+++ b/caneth/client.py
@@ -563,10 +563,12 @@ class WaveShareCANClient:
 
                     writer = self._writer
                     if writer is None:
-                        # Lost connection; push back and break to outer wait
+                        # Lost connection detected here; make state consistent.
                         async with self._tx_cv:
                             self._tx_buf.appendleft(raw)
                             self._tx_cv.notify()
+                        self._connected.clear()
+                        await asyncio.sleep(0)  # avoid potential tight re-loop
                         break
 
                     try:

--- a/caneth/client.py
+++ b/caneth/client.py
@@ -553,7 +553,7 @@ class WaveShareCANClient:
                         else:
                             # Wait for new data or disconnection/close
                             try:
-                                await asyncio.wait_for(self._tx_cv.wait(), timeout=WaveShareCANClient._TX_WAIT_TIMEOUT)
+                                await asyncio.wait_for(self._tx_cv.wait(), timeout=self._TX_WAIT_TIMEOUT)
                             except asyncio.TimeoutError:
                                 # Timeout occurred; no new data, continue loop
                                 continue
@@ -596,7 +596,7 @@ class WaveShareCANClient:
                 break
             except Exception:
                 self.log.exception("Unexpected error in TX loop")
-                await asyncio.sleep(WaveShareCANClient._TX_WAIT_TIMEOUT)
+                await asyncio.sleep(self._TX_WAIT_TIMEOUT)
 
     async def _dispatch(self, frame: CANFrame) -> None:
         """Run global observers, specific callbacks, and resolve waiters."""

--- a/caneth/client.py
+++ b/caneth/client.py
@@ -568,15 +568,7 @@ class WaveShareCANClient:
                             self._tx_buf.appendleft(raw)
                             self._tx_cv.notify()
                         self._connected.clear()
-                        # tells the scheduler: “yield now; let other tasks run.”
-                        # That gives the reconnect manager (and teardown paths that
-                        # notify the condition, close the writer, etc.) a chance to
-                        # advance the state before TX loops again. It:
-                        # - prevents a CPU spin,
-                        # - avoids starving the reconnect task,
-                        # - does not introduce a real delay (it yields, not sleeps).
-                        # In 3.12+, await asyncio.sleep(0) remains the recommended
-                        # simple yield; there’s no dedicated “yield” primitive.
+                        # Yield to avoid a tight loop and let reconnect/teardown tasks run.
                         await asyncio.sleep(0)  # avoid potential tight re-loop
                         break
 

--- a/caneth/client.py
+++ b/caneth/client.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from collections import deque
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 
@@ -115,13 +116,17 @@ class WaveShareCANClient:
         reconnect_cap: When reconnect_max == 0 (retry forever), cap backoff to this many seconds (default 60).
         name: Logger name suffix.
 
+        # Sending / buffering
+        send_buffer_limit: Max number of frames kept in memory (default 1024).
+        drop_oldest_on_full: If True (default), drop the oldest frame when buffer is full.
+                             If False, `send()` will apply back-pressure and wait for space.
+
     Behavior:
-    - Connects and reads fixed 13-byte frames in a loop.
-    - Automatically reconnects on EOF or socket errors (see backoff knobs).
-    - `on_frame()` registers global observers.
-    - `register_callback(id[, d0[, d1]], cb)` registers matchers by ID and optional first bytes.
-    - `wait_for(id[, d0[, d1]], timeout=None, callback=None)` awaits a matching frame and
-      optionally calls `callback(frame)` when it arrives.
+    - Connects and reads fixed 13-byte frames in a loop; auto-reconnects on errors.
+    - Global observers via `on_frame()`.
+    - Specific callbacks via `register_callback(id[, d0[, d1]], cb)`.
+    - `wait_for(id[, d0[, d1]], timeout=None, callback=None)`.
+    - **Buffered send**: `send()` enqueues a frame; a background TX loop flushes when connected.
     """
 
     def __init__(
@@ -131,6 +136,9 @@ class WaveShareCANClient:
         reconnect_initial: float = 0.5,
         reconnect_max: float = 10.0,
         reconnect_cap: float = 60.0,
+        *,
+        send_buffer_limit: int = 1024,
+        drop_oldest_on_full: bool = True,
         name: str = "can1",
     ) -> None:
         self.host = host
@@ -139,10 +147,17 @@ class WaveShareCANClient:
         self.reconnect_max = float(reconnect_max)
         self.reconnect_cap = float(reconnect_cap)
 
+        # Outgoing buffered frames (already encoded as 13-byte chunks)
+        self._tx_buf: deque[bytes] = deque()
+        self._tx_cv: asyncio.Condition = asyncio.Condition()
+        self._send_buffer_limit = int(send_buffer_limit)
+        self._drop_oldest_on_full = bool(drop_oldest_on_full)
+
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
-        self._task: asyncio.Task[None] | None = None
+        self._mgr_task: asyncio.Task[None] | None = None
         self._rx_task: asyncio.Task[None] | None = None
+        self._tx_task: asyncio.Task[None] | None = None
 
         self._connected = asyncio.Event()
         self._closed = asyncio.Event()
@@ -163,40 +178,59 @@ class WaveShareCANClient:
     # ----------------------------- Lifecycle -----------------------------
 
     async def start(self) -> None:
-        """Start the background connection manager task."""
-        if self._task and not self._task.done():
+        """Start the background manager (connect/reconnect), RX loop and TX loop."""
+        if self._mgr_task and not self._mgr_task.done():
             return
         self._closed.clear()
-        self._task = asyncio.create_task(self._run(), name="caneth-run")
+        self._mgr_task = asyncio.create_task(self._run(), name="caneth-run")
+        # Start TX loop once; it waits on connection and buffer content.
+        if not self._tx_task or self._tx_task.done():
+            self._tx_task = asyncio.create_task(self._tx_loop(), name="caneth-tx")
 
     async def close(self) -> None:
-        """
-        Signal close and wait for background tasks.
-        Safe to call multiple times.
-        """
+        """Signal close and wait for background tasks. Safe to call multiple times."""
         self._closed.set()
         self._connected.clear()
 
+        # Wake TX waiters
+        async with self._tx_cv:
+            self._tx_cv.notify_all()
+
+        # Cancel RX/TX tasks
         if self._rx_task:
             self._rx_task.cancel()
-            # swallow the cancellation from the rx task
             with contextlib.suppress(asyncio.CancelledError):
                 await self._rx_task
             self._rx_task = None
 
+        if self._tx_task:
+            self._tx_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._tx_task
+            self._tx_task = None
+
         await self._teardown_io()
 
-        if self._task:
-            # don't let close() raise if the run task is already ending
+        if self._mgr_task:
             with contextlib.suppress(Exception):
-                await asyncio.wait_for(self._task, timeout=1.0)
-            self._task = None
+                await asyncio.wait_for(self._mgr_task, timeout=1.0)
+            self._mgr_task = None
 
     async def wait_connected(self, timeout: float | None = None) -> None:
         """Wait until the TCP connection is established (or timeout)."""
         await asyncio.wait_for(self._connected.wait(), timeout=timeout)
 
     # ------------------------------- API --------------------------------
+
+    def buffer_size(self) -> int:
+        """Current number of frames waiting in the send buffer."""
+        return len(self._tx_buf)
+
+    async def clear_buffer(self) -> None:
+        """Drop all buffered frames (not yet sent)."""
+        async with self._tx_cv:
+            self._tx_buf.clear()
+            self._tx_cv.notify_all()
 
     def on_frame(self, callback: Callback) -> None:
         """
@@ -337,16 +371,23 @@ class WaveShareCANClient:
         *,
         extended: bool | None = None,
         rtr: bool = False,
+        wait_for_space: bool = False,
     ) -> None:
         """
-        Send a single frame.
+        Enqueue a frame for sending. The TX loop will flush it when connected.
 
         Args:
             can_id: Integer CAN ID.
-            data: Byte-like payload (0..8 bytes). Iterable[int] accepted and packed.
-            extended: Force extended (29-bit) or standard (11-bit). If None, inferred from `can_id > 0x7FF`.
+            data: Byte-like payload (0..8 bytes). Iterable[int] accepted.
+            extended: Force extended or standard. If None, inferred as (can_id > 0x7FF).
             rtr: Remote frame flag.
+            wait_for_space: If True and buffer is full and `drop_oldest_on_full=False`,
+                            this call will block until space is available.
         """
+        # If the client was explicitly closed, sending is an error.
+        if self._closed.is_set():
+            raise RuntimeError("Client is closed")
+
         payload = bytes(data) if not isinstance(data, bytes | bytearray) else bytes(data)
         if len(payload) > 8:
             raise ValueError("data length must be <= 8")
@@ -355,11 +396,33 @@ class WaveShareCANClient:
         frame = CANFrame(can_id=int(can_id), data=payload, extended=bool(extended), rtr=bool(rtr), dlc=len(payload))
         raw = frame.to_bytes()
 
-        writer = self._writer
-        if writer is None:
-            raise RuntimeError("Not connected")
-        writer.write(raw)
-        await writer.drain()
+        async with self._tx_cv:
+            # Fast path: space available
+            if len(self._tx_buf) < self._send_buffer_limit:
+                self._tx_buf.append(raw)
+                self._tx_cv.notify()
+                return
+
+            # Buffer full
+            if self._drop_oldest_on_full:
+                # Drop oldest, enqueue newest
+                _ = self._tx_buf.popleft()
+                self._tx_buf.append(raw)
+                self._tx_cv.notify()
+                return
+
+            if not wait_for_space:
+                # Respect limit; drop this frame silently or log a warning
+                self.log.warning("TX buffer full; dropping frame id=0x%X", can_id)
+                return
+
+            # Back-pressure: wait for space
+            while len(self._tx_buf) >= self._send_buffer_limit and not self._closed.is_set():
+                await self._tx_cv.wait()
+            if self._closed.is_set():
+                return
+            self._tx_buf.append(raw)
+            self._tx_cv.notify()
 
     # ---------------------------- Internals --------------------------------
 
@@ -433,12 +496,12 @@ class WaveShareCANClient:
             except Exception:
                 pass
 
-    async def _read_loop(self) -> None:
-        """
-        Read fixed 13-byte frames, decode, and dispatch.
+        # Wake any senders waiting for space (so they can exit if closed)
+        async with self._tx_cv:
+            self._tx_cv.notify_all()
 
-        Exits on EOF or IncompleteReadError.
-        """
+    async def _read_loop(self) -> None:
+        """Read fixed 13-byte frames, decode, and dispatch. Exits on EOF."""
         reader = self._reader
         if reader is None:
             return
@@ -463,6 +526,65 @@ class WaveShareCANClient:
             except Exception:
                 self.log.exception("Error during dispatch")
 
+    async def _tx_loop(self) -> None:
+        """
+        Background transmitter: flush buffered frames when connected.
+
+        - Waits for `_connected` before attempting writes.
+        - On write error, re-queues the frame at the head and waits for reconnection.
+        """
+        while not self._closed.is_set():
+            # Wait until we have a connection
+            await self._connected.wait()
+            if self._closed.is_set():
+                break
+
+            # Drain buffer while connected
+            try:
+                while self._connected.is_set() and not self._closed.is_set():
+                    raw: bytes | None = None
+                    async with self._tx_cv:
+                        if self._tx_buf:
+                            raw = self._tx_buf.popleft()
+                            # notify space for potential waiters
+                            self._tx_cv.notify()
+                        else:
+                            # Wait for new data or disconnection/close
+                            await asyncio.wait(
+                                [asyncio.create_task(self._connected.wait()), asyncio.create_task(self._closed.wait())],
+                                timeout=0.05,
+                            )
+                            continue
+
+                    if raw is None:
+                        continue
+
+                    writer = self._writer
+                    if writer is None:
+                        # Lost connection; push back and break to outer wait
+                        async with self._tx_cv:
+                            self._tx_buf.appendleft(raw)
+                            self._tx_cv.notify()
+                        break
+
+                    try:
+                        writer.write(raw)
+                        await writer.drain()
+                    except Exception as e:
+                        self.log.warning("Write error: %s; will retry after reconnect", e)
+                        # Re-queue at head to preserve order
+                        async with self._tx_cv:
+                            self._tx_buf.appendleft(raw)
+                            self._tx_cv.notify()
+                        # Force reconnect handling by clearing the flag
+                        self._connected.clear()
+                        break
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                self.log.exception("Unexpected error in TX loop")
+                await asyncio.sleep(0.05)
+
     async def _dispatch(self, frame: CANFrame) -> None:
         """Run global observers, specific callbacks, and resolve waiters."""
         # 1) Global observers
@@ -476,14 +598,11 @@ class WaveShareCANClient:
 
         # 2) Specific callbacks with optional wildcards
         candidates: list[CallbackKey] = []
-        # ID-only
-        candidates.append((frame.can_id, None, None))
-        # ID + d0
+        candidates.append((frame.can_id, None, None))  # ID only
         if frame.dlc >= 1:
-            candidates.append((frame.can_id, frame.data[0], None))
-        # ID + d0 + d1
+            candidates.append((frame.can_id, frame.data[0], None))  # ID + d0
         if frame.dlc >= 2:
-            candidates.append((frame.can_id, frame.data[0], frame.data[1]))
+            candidates.append((frame.can_id, frame.data[0], frame.data[1]))  # ID + d0 + d1
 
         seen: set[int] = set()
         for key in candidates:
@@ -513,7 +632,6 @@ class WaveShareCANClient:
                 to_complete.append(w)
 
             for w in to_complete:
-                # remove from list first to avoid race
                 with contextlib.suppress(ValueError):
                     self._waiters.remove(w)
                 if not w.fut.done():

--- a/caneth/client.py
+++ b/caneth/client.py
@@ -414,7 +414,7 @@ class WaveShareCANClient:
                 return
 
             if not wait_for_space:
-                # Respect limit; drop this frame silently or log a warning
+                # Respect limit; drop this frame and log a warning
                 self.log.warning("TX buffer full; dropping frame id=0x%X", can_id)
                 return
 

--- a/tests/test_rx_writer_none_midloop.py
+++ b/tests/test_rx_writer_none_midloop.py
@@ -1,0 +1,53 @@
+import asyncio
+
+import pytest
+from caneth.client import WaveShareCANClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_writer_none_midloop_requeues_and_clears_connected(ws_server):
+    """
+    Simulate a race where _writer becomes None just as the TX loop is about to write.
+
+    Expected:
+      - The popped frame is re-queued (buffer_size stays 1).
+      - Nothing is sent to the server.
+      - _connected is cleared by the TX loop (so reconnect policy can run).
+    """
+    host, port, state = ws_server
+
+    client = WaveShareCANClient(
+        host,
+        port,
+        name="tx-writer-none",
+        send_buffer_limit=8,
+        drop_oldest_on_full=True,
+    )
+
+    # Start and connect normally
+    await client.start()
+    await client.wait_connected(timeout=2.0)
+    await state.wait_client_connected(timeout=2.0)
+
+    # Force the 'writer is None' branch:
+    # Make the current writer disappear *before* enqueuing a frame,
+    # so when TX loop wakes, it pops the frame and then sees writer None.
+    client._writer = None  # intentional: simulate abrupt writer loss
+
+    # Enqueue one frame; TX loop will pop it, see writer is None, requeue at head,
+    # clear _connected, and break the inner loop.
+    await client.send(0x777, b"\x01")
+
+    # Give the TX loop a tick to process the buffer
+    await asyncio.sleep(0.05)
+
+    # The frame should still be in the buffer (re-queued), and connection should be marked lost
+    assert client.buffer_size() == 1, "Frame should be re-queued after writer loss"
+    assert not client._connected.is_set(), "_connected should be cleared by TX loop"
+
+    # The server must not receive anything because no actual write happened
+    with pytest.raises(asyncio.TimeoutError):
+        await state.recv(timeout=0.2)
+
+    await client.close()

--- a/tests/test_send_buffer.py
+++ b/tests/test_send_buffer.py
@@ -1,0 +1,148 @@
+import asyncio
+
+import pytest
+from caneth.client import WaveShareCANClient
+
+from .conftest import build_frame
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_enqueue_before_start_flushes_on_connect(ws_server):
+    """
+    Frames enqueued before starting/connecting should flush on connect in FIFO order.
+    """
+    host, port, state = ws_server
+
+    client = WaveShareCANClient(host, port, name="buf-prestart")
+    # Enqueue before starting the client
+    await client.send(0x100, b"\x01")
+    await client.send(0x101, b"\x02\x03")
+    assert client.buffer_size() == 2
+
+    # Start + connect; server should receive both frames
+    await client.start()
+    await client.wait_connected(timeout=2.0)
+    await state.wait_client_connected(timeout=2.0)
+
+    got1 = await state.recv(timeout=2.0)
+    got2 = await state.recv(timeout=2.0)
+
+    assert got1 == build_frame(0x100, b"\x01", extended=False)
+    assert got2 == build_frame(0x101, b"\x02\x03", extended=False)
+    await client.close()
+
+
+async def test_drop_oldest_when_full(ws_server):
+    """
+    With drop_oldest_on_full=True and buffer limit N, the oldest frame is dropped
+    when enqueuing beyond the limit; only the newest N are delivered.
+    """
+    host, port, state = ws_server
+
+    client = WaveShareCANClient(
+        host,
+        port,
+        name="buf-drop-oldest",
+        send_buffer_limit=2,
+        drop_oldest_on_full=True,
+    )
+
+    # Enqueue 3 frames with limit=2 — expect to drop the first (0x200)
+    await client.send(0x200, b"\xaa")
+    await client.send(0x201, b"\xbb")
+    await client.send(0x202, b"\xcc")
+    assert client.buffer_size() == 2  # only last 2 kept
+
+    await client.start()
+    await client.wait_connected(timeout=2.0)
+    await state.wait_client_connected(timeout=2.0)
+
+    got1 = await state.recv(timeout=2.0)  # should be 0x201
+    got2 = await state.recv(timeout=2.0)  # then 0x202
+
+    assert got1 == build_frame(0x201, b"\xbb", extended=False)
+    assert got2 == build_frame(0x202, b"\xcc", extended=False)
+
+    # No extra frames should arrive
+    with pytest.raises(asyncio.TimeoutError):
+        await state.recv(timeout=0.2)
+
+    await client.close()
+
+
+async def test_backpressure_wait_for_space(ws_server):
+    """
+    With drop_oldest_on_full=False and wait_for_space=True, a sender blocks
+    until the buffer has room, preserving all frames and order.
+    """
+    host, port, state = ws_server
+
+    client = WaveShareCANClient(
+        host,
+        port,
+        name="buf-backpressure",
+        send_buffer_limit=1,
+        drop_oldest_on_full=False,
+    )
+
+    # Fill the buffer with one frame
+    await client.send(0x300, b"\x01")  # buffer now full
+
+    # Start a second send that must wait for space
+    send_done = asyncio.Event()
+
+    async def _blocked_send():
+        await client.send(0x301, b"\x02", wait_for_space=True)
+        send_done.set()
+
+    task = asyncio.create_task(_blocked_send())
+
+    # Make sure it's blocked (no connection yet to drain the buffer)
+    await asyncio.sleep(0.05)
+    assert not send_done.is_set()
+
+    # Now connect; buffer will flush and unblock the second send
+    await client.start()
+    await client.wait_connected(timeout=2.0)
+    await state.wait_client_connected(timeout=2.0)
+
+    # First frame out
+    got1 = await state.recv(timeout=2.0)
+    assert got1 == build_frame(0x300, b"\x01", extended=False)
+
+    # Second sender should complete once space is freed and the frame is enqueued
+    await asyncio.wait_for(send_done.wait(), timeout=1.0)
+
+    # And then second frame out
+    got2 = await state.recv(timeout=2.0)
+    assert got2 == build_frame(0x301, b"\x02", extended=False)
+
+    await client.close()
+    await asyncio.gather(task, return_exceptions=True)
+
+
+async def test_clear_buffer_drops_pending(ws_server):
+    """
+    clear_buffer() removes any queued frames so nothing gets sent on connect.
+    """
+    host, port, state = ws_server
+
+    client = WaveShareCANClient(host, port, name="buf-clear")
+    await client.send(0x400, b"\xde\xad")
+    await client.send(0x401, b"\xbe\xef")
+    assert client.buffer_size() == 2
+
+    # Clear and verify
+    await client.clear_buffer()
+    assert client.buffer_size() == 0
+
+    # Start and connect; server should not receive anything
+    await client.start()
+    await client.wait_connected(timeout=2.0)
+    await state.wait_client_connected(timeout=2.0)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await state.recv(timeout=0.2)
+
+    await client.close()


### PR DESCRIPTION
## Summary

This PR adds a transmission buffer feature to the WaveShareCANClient to queue outgoing frames and send them asynchronously when the connection is available.

- Adds buffered sending capability with configurable buffer limits and overflow handling
- Implements a separate TX loop that manages frame transmission when connected
- Provides backpressure mechanisms and buffer management APIs


## What’s changed
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance / Refactor
- [ ] Tests

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (README/Examples/Docstrings)
- [x] `ruff check` and `ruff format` pass
- [x] `mypy caneth` passes
- [ ] CI green

## Related issues
Adds a new feature to buffer the data to be send.

