### PR TITLE
fix(tx): correct _tx_loop to pop _TxItem and send frames contiguously

### DIFF
--- a/caneth/client.py
+++ b/caneth/client.py
@@ -62,6 +62,8 @@ class _TxItem:
     frames: list[bytes]  # one or more 13-byte encoded frames
     atomic: bool  # if True, must not be interleaved
     can_id: int | None = None  # optional metadata (for logging)
+
+
 @dataclass(slots=True)
 class CANFrame:
     """

--- a/caneth/client.py
+++ b/caneth/client.py
@@ -694,6 +694,18 @@ class WaveShareCANClient:
                 self._tx_buf.append(item)
                 self._tx_cv.notify()
 
+    def atomic(
+        self, can_id: int, *, extended: bool | None = None, rtr: bool = False, wait_for_space: bool = False
+    ) -> _AtomicSender:
+        """
+        Usage:
+            async with client.atomic(0x123) as a:
+                await a.send(b"\x01")
+                await a.send(b"\x02")
+        Both frames are sent contiguously (no interleaving).
+        """
+        return _AtomicSender(self, can_id, extended=extended, rtr=rtr, wait_for_space=wait_for_space)
+
 
 class _AtomicSender:
     def __init__(
@@ -724,16 +736,3 @@ class _AtomicSender:
                 rtr=self._rtr,
                 wait_for_space=self._wait,
             )
-
-
-def atomic(
-    self, can_id: int, *, extended: bool | None = None, rtr: bool = False, wait_for_space: bool = False
-) -> _AtomicSender:
-    """
-    Usage:
-        async with client.atomic(0x123) as a:
-            await a.send(b"\x01")
-            await a.send(b"\x02")
-    Both frames are sent contiguously (no interleaving).
-    """
-    return _AtomicSender(self, can_id, extended=extended, rtr=rtr, wait_for_space=wait_for_space)

--- a/caneth/client.py
+++ b/caneth/client.py
@@ -587,8 +587,8 @@ class WaveShareCANClient:
                     # Send all frames in this item contiguously
                     sent = 0  # how many frames were fully sent+drained
                     try:
-                        for idx, frame_bytes in enumerate(item.frames):
-                            writer.write(frame_bytes)
+                        for idx, frame_data in enumerate(item.frames):
+                            writer.write(frame_data)
                             await writer.drain()
                             sent = idx + 1  # we finished this one successfully
                     except (asyncio.CancelledError, GeneratorExit):
@@ -599,7 +599,9 @@ class WaveShareCANClient:
                         remaining = item.frames[sent:]
                         if remaining:
                             async with self._tx_cv:
-                                self._tx_buf.appendleft(_TxItem(frames=remaining, atomic=True, can_id=item.can_id))
+                                self._tx_buf.appendleft(
+                                    _TxItem(frames=remaining, atomic=item.atomic, can_id=item.can_id)
+                                )
                                 self._tx_cv.notify()
                         self._connected.clear()  # hand control to reconnect manager
                         break

--- a/caneth/client.py
+++ b/caneth/client.py
@@ -34,13 +34,34 @@ __all__ = ["CANFrame", "WaveShareCANClient"]
 
 @dataclass(slots=True)
 class _TxItem:
-    """One atomic unit for transmission."""
+    """
+    One atomic unit for transmission.
+
+    The `atomic` field controls frame ordering and interleaving guarantees:
+
+    - If `atomic=True`, all frames in `frames` are sent together, without interleaving
+      with frames from other transmissions. This guarantees that the sequence of frames
+      is preserved, even across reconnections. If a reconnection occurs before all frames
+      are sent, the entire atomic group will be retransmitted, ensuring ordering and atomicity.
+
+    - If `atomic=False`, frames may be interleaved with other transmissions. There is no
+      guarantee that the frames will be sent together or in order relative to other frames.
+      During reconnection, only unsent frames will be retransmitted, and ordering may not
+      be preserved.
+
+    Use `atomic=True` when frame ordering and atomic delivery are required (e.g., for
+    multi-frame transactions or protocols that require strict sequencing). Use `atomic=False`
+    for independent frames where ordering and grouping are not critical.
+
+    Attributes:
+        frames: List of one or more 13-byte encoded frames to transmit.
+        atomic: If True, frames are sent as an atomic group; if False, frames may be interleaved.
+        can_id: Optional CAN ID metadata (for logging).
+    """
 
     frames: list[bytes]  # one or more 13-byte encoded frames
     atomic: bool  # if True, must not be interleaved
     can_id: int | None = None  # optional metadata (for logging)
-
-
 @dataclass(slots=True)
 class CANFrame:
     """

--- a/tests/test_atomic_context.py
+++ b/tests/test_atomic_context.py
@@ -1,0 +1,119 @@
+import asyncio
+
+import pytest
+from caneth.client import WaveShareCANClient
+
+from .conftest import build_frame
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_atomic_context_no_interleave(ws_server):
+    """
+    Frames added within `async with client.atomic(can_id)` must be sent
+    back-to-back (no interleaving), relative to other frames.
+    """
+    host, port, state = ws_server
+
+    client = WaveShareCANClient(
+        host,
+        port,
+        name="atomic-no-interleave",
+        send_buffer_limit=16,
+        drop_oldest_on_full=True,
+    )
+
+    # Enqueue something BEFORE the batch
+    await client.send(0x100, b"\xa0")
+
+    # Start & connect
+    await client.start()
+    await client.wait_connected(timeout=2.0)
+    await state.wait_client_connected(timeout=2.0)
+
+    # Create an atomic batch for a different CAN ID
+    async with client.atomic(0x222) as a:
+        await a.send(b"\x01")
+        await a.send(b"\x02")
+        await a.send(b"\x03")
+
+    # Enqueue something AFTER the batch
+    await client.send(0x100, b"\xa1")
+
+    # Expect order: A0, [batch 01, 02, 03 contiguous], A1
+    got1 = await state.recv(timeout=2.0)
+    got2 = await state.recv(timeout=2.0)
+    got3 = await state.recv(timeout=2.0)
+    got4 = await state.recv(timeout=2.0)
+    got5 = await state.recv(timeout=2.0)
+
+    assert got1 == build_frame(0x100, b"\xa0", extended=False)
+
+    # Batch frames contiguous, same CAN ID
+    assert got2 == build_frame(0x222, b"\x01", extended=False)
+    assert got3 == build_frame(0x222, b"\x02", extended=False)
+    assert got4 == build_frame(0x222, b"\x03", extended=False)
+
+    assert got5 == build_frame(0x100, b"\xa1", extended=False)
+
+    # No more frames
+    with pytest.raises(asyncio.TimeoutError):
+        await state.recv(timeout=0.2)
+
+    await client.close()
+
+
+async def test_atomic_context_mid_batch_disconnect(ws_server):
+    """
+    If the connection drops mid-batch, the remaining frames of that atomic
+    batch must be re-queued together and delivered contiguously after reconnect.
+    """
+    host, port, state = ws_server
+
+    client = WaveShareCANClient(
+        host,
+        port,
+        name="atomic-mid-drop",
+        send_buffer_limit=16,
+        drop_oldest_on_full=True,
+    )
+
+    await client.start()
+    await client.wait_connected(timeout=2.0)
+    await state.wait_client_connected(timeout=2.0)
+
+    # Enqueue an atomic batch of three frames
+    async with client.atomic(0x333) as a:
+        await a.send(b"\x10")
+        await a.send(b"\x11")
+        await a.send(b"\x12")
+
+    # Receive the first frame of the batch
+    first = await state.recv(timeout=2.0)
+    assert first == build_frame(0x333, b"\x10", extended=False)
+
+    # Simulate mid-batch disconnect: close the client's writer transport.
+    # This will cause the next write/drain to fail and trigger the TX loop's
+    # requeue of the remaining frames as a single atomic item.
+    w = client._writer  # type: ignore[attr-defined]
+    if w is not None:
+        try:
+            w.close()
+            await w.wait_closed()
+        except Exception:
+            pass
+
+    # The client should reconnect automatically
+    await state.wait_client_connected(timeout=2.0)
+
+    # Remaining two frames must arrive contiguously and in order
+    rem1 = await state.recv(timeout=2.0)
+    rem2 = await state.recv(timeout=2.0)
+    assert rem1 == build_frame(0x333, b"\x11", extended=False)
+    assert rem2 == build_frame(0x333, b"\x12", extended=False)
+
+    # No extras
+    with pytest.raises(asyncio.TimeoutError):
+        await state.recv(timeout=0.2)
+
+    await client.close()


### PR DESCRIPTION
## Summary
- pop `_TxItem` (not raw bytes) and check `item is None`
- avoid variable shadowing; use `frame_bytes` in send loop
- on writer=None: requeue whole item, clear `_connected`, yield
- on write error: requeue remaining frames as one atomic item
- preserves non-interleaving batches and prevents tight re-loops

## What’s changed
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance / Refactor
- [ ] Tests

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (README/Examples/Docstrings)
- [x] `ruff check` and `ruff format` pass
- [x] `mypy caneth` passes
- [ ] CI green

