### PR TITLE
fix: workaround to address waveshare issue

### DIFF
--- a/caneth/client.py
+++ b/caneth/client.py
@@ -610,10 +610,10 @@ class WaveShareCANClient:
                     # Send all frames in this item contiguously
                     sent = 0  # how many frames were fully sent+drained
                     try:
-                        for idx, frame_data in enumerate(item.frames):
-                            writer.write(frame_data)
-                            await writer.drain()
-                            sent = idx + 1  # we finished this one successfully
+                        data = b"".join(item.frames)
+                        writer.write(data)
+                        await writer.drain()
+                        sent = len(item.frames)
                     except (asyncio.CancelledError, GeneratorExit):
                         raise  # don't swallow cancellations
                     except Exception as e:


### PR DESCRIPTION
## Summary

This PR implements a workaround to address a Waveshare-related issue by modifying the frame transmission logic in the client code. Instead of sending frames individually in a loop, the code now concatenates all frames into a single byte string before sending.

- Replaces individual frame sending with bulk concatenation and single write operation
- Updates the sent frame counter to reflect all frames being processed together
- Maintains the same error handling and drain behavior
